### PR TITLE
feat(tests): add pytest for group8 

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           pytest
         working-directory: tests/group3  
+      - name: Run G8 tests
+        run: |
+          pytest
+        working-directory: tests/group8
       - name: Run tests
         run: |
           pytest


### PR DESCRIPTION
Added a new step in the GitHub Actions workflow to run pytest for the
tests located in the 'tests/group8' directory. This ensures that the
tests for group8 are executed as part of the CI pipeline.